### PR TITLE
soar.c: Simplifications, bugfixes, tweaks

### DIFF
--- a/src/soar.c
+++ b/src/soar.c
@@ -362,12 +362,12 @@ static void SoarHBlankCallback(void)
     // Note that the lxr shifts down first!
 
     // horizontal offset
-    lxr= 30 * lcf;
+    lxr= 120 * (lsf>>4);
     lyr= lsf<<3;
     REG_BG2X= sPlayerPosX - lxr + lyr;
 
     // vertical offset
-    lxr= 30 * lsf;
+    lxr= 120 * (lsf>>4);
     lyr= lcf<<3;
     REG_BG2Y= sPlayerPosY - lxr - lyr;
 }


### PR DESCRIPTION
* Use GBA typedefs.
* Reduce unnecessary precision.
* Simplify math operations with bitshifts and don't do things twice.
* Fix May suddenly changing gender.
* When the user is not turning, the barrel roll direction is randomized.
* The Lati@s sprite was slightly lowered.